### PR TITLE
Add footnote syntax to markdown.md

### DIFF
--- a/editors/markdown.md
+++ b/editors/markdown.md
@@ -182,12 +182,12 @@ Use the syntax `[^1]` for the location of the footnote in the main text, and `[^
 ```markdown
 This sentence[^1] needs a few footnotes.[^2]
 
-[^1]: A string of syntatic words.
+[^1]: A string of syntactic words.
 [^2]: A useful example sentence.
 ```
 This sentence[^1] needs a few footnotes.[^2]
 
-[^1]: A string of syntatic words.
+[^1]: A string of syntactic words.
 [^2]: A useful example sentence.
 
 ## Headers

--- a/editors/markdown.md
+++ b/editors/markdown.md
@@ -169,6 +169,27 @@ Can be also be used :fire: inline
 
 Can also be used :fire: inline.
 
+## Footnotes
+
+### Tab {.tabset}
+
+#### Usage
+
+Use the syntax `[^1]` for the location of the footnote in the main text, and `[^1]: this is a footnote` for the actual footnote.  Footnotes themselves will automatically appear at the bottom of the page under a horizontal line.
+
+#### Examples
+
+```markdown
+This sentence[^1] needs a few footnotes.[^2]
+
+[^1]: A string of syntatic words.
+[^2]: A useful example sentence.
+```
+This sentence[^1] needs a few footnotes.[^2]
+
+[^1]: A string of syntatic words.
+[^2]: A useful example sentence.
+
 ## Headers
 
 ### Tab {.tabset}


### PR DESCRIPTION
Added the syntax for footnotes in Wiki.js to the markdown documentation.