### PR TITLE
Add Cloudron installation platform

### DIFF
--- a/install.md
+++ b/install.md
@@ -12,6 +12,7 @@ dateCreated: 2019-02-15T04:22:28.058Z
 {.is-info}
 
 ## By Platform
+- [Cloudron](https://www.cloudron.io/store/org.wikijs.cloudronapp.html)
 - [Docker](/install/docker)
 - [Heroku](/install/heroku)
 - [Kubernetes](/install/kubernetes)


### PR DESCRIPTION
We at cloudron maintain a wiki.js package since a long time now. Usually we publish updates within one/two days of upstream release, once our [e2e package tests](https://git.cloudron.io/cloudron/wikijs-app/-/tree/master/test) located at succeed.