### PR TITLE
Add alwaysdata deployment page.

### DIFF
--- a/install.md
+++ b/install.md
@@ -2,7 +2,7 @@
 title: Installation
 description: How to install Wiki.js
 published: true
-date: 2022-02-28T03:52:46.998Z
+date: 2022-03-03T13:02:46.998Z
 tags: setup
 editor: markdown
 dateCreated: 2019-02-15T04:22:28.058Z
@@ -19,6 +19,7 @@ dateCreated: 2019-02-15T04:22:28.058Z
 ## By Platform
 - [Docker](/install/docker)
 - [Heroku](/install/heroku)
+- [alwaysdata](/install/alwaysdata)
 - [Kubernetes](/install/kubernetes)
 - [Linux](/install/linux)
 - [macOS](/install/macos)

--- a/install/alwaysdata.md
+++ b/install/alwaysdata.md
@@ -1,0 +1,15 @@
+---
+title: alwaysdata
+description: Getting started with a Wiki.js installation on alwaysdata
+published: true
+date: 2022-03-03T13:01:40.092Z
+tags: setup
+editor: markdown
+dateCreated: 2022-03-03T13:01:40.092Z
+---
+
+alwaysdata is a Platform-as-a-Service (PaaS) providing Public and Private Cloud offers. Starting with a free plan they provide MySQL/PostgreSQL databases, emails, free SSL certificates, included backups, etc.
+
+Wiki.js is available on their Marketplace:
+
+[Install Wiki.js on alwaysdata](https://www.alwaysdata.com/en/marketplace/wikijs/)


### PR DESCRIPTION
Wiki.js is available on alwaysdata Marketplace, providing a very easy installation process.