### PR TITLE
Enable use with Podman Compose and explain DB_HOST

### DIFF
--- a/install/docker.md
+++ b/install/docker.md
@@ -175,6 +175,10 @@ volumes:
   db-data:
 ```
 
+`DB_HOST` should match the service name (in this case, `db`). If `container_name` is specified for the service, its value should be used instead.
+
+The above Docker Compose file should be compatible with rootless Podman Compose by default as long as you have `aardvark-dns` installed on the host.
+
 ![](https://a.icons8.com/jihZbhdR/4WJoF7/svg.svg){.align-abstopright}
 
 # ARM images


### PR DESCRIPTION
This PR is simple and does two things:

* mentions how DB_HOST behaves to access the database
* mentions what is needed to run Wiki.js on Podman

The first issue gave me cryptic errors about the wiki container being unable to access the database container, as it isn't quite obvious. The second was due to my distribution not installing aardvark by default with podman, as it is a relatively new DNS backend for podman.