### PR TITLE
Update Markdown and AsciiDoc Editor Pages

### DIFF
--- a/editors/asciidoc.md
+++ b/editors/asciidoc.md
@@ -2,7 +2,7 @@
 title: AsciiDoc
 description: Editor
 published: true
-date: 2022-12-24T02:46:14.354Z
+date: 2024-11-12T23:20:00.000Z
 tags: editors
 editor: markdown
 dateCreated: 2022-12-24T02:46:14.354Z
@@ -21,3 +21,15 @@ See the [AsciiDoc Language Documentation](https://docs.asciidoctor.org/asciidoc/
 
 > Note that only a limited set of AsciiDoc features are supported at the moment.
 {.is-warning}
+
+# Stylings
+
+## Admonitions
+
+In addition to the **5** [standard types](https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/) provided by AsciiDoc, Wiki.js extends the syntax to include the **success** blockquote from the [Markdown Editor](../markdown.md).
+This extension is implemented as a [Block Processor](https://docs.asciidoctor.org/asciidoctor/latest/extensions/block-processor/) as follows:
+
+```adoc
+[Success]
+Success is now.
+```

--- a/editors/markdown.md
+++ b/editors/markdown.md
@@ -42,7 +42,8 @@ Using a **greater-than** symbol, followed by a space, before each line of text.
 By adding a class on a separate line, after the blockquote, you can change the look of the blockquote. Note that these stylings are specific to Wiki.js and will fallback to standard blockquote styling in other applications.
 
 - Blue: `is-info`
-- Green: `is-success`
+- Green: `is-success` & `is-tip`
+- Purple: `is-caution`
 - Yellow: `is-warning`
 - Red: `is-danger`
 
@@ -59,6 +60,12 @@ By adding a class on a separate line, after the blockquote, you can change the l
 
 > This is a `{.is-success}` blockquote.
 {.is-success}
+
+> This is a `{.is-tip}` blockquote.
+{.is-tip}
+
+> This is a `{.is-caution}` blockquote.
+{.is-caution}
 
 > This is a `{.is-warning}` blockquote.
 {.is-warning}

--- a/editors/markdown.md
+++ b/editors/markdown.md
@@ -2,7 +2,7 @@
 title: Markdown
 description: Editor
 published: true
-date: 2024-10-06T23:51:50.138Z
+date: 2024-11-12T23:20:00.000Z
 tags: editors
 editor: markdown
 dateCreated: 2019-05-22T02:59:46.078Z


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is dependent upon https://github.com/requarks/wiki/pull/7390 being approved

Updated the wiki docs pages for the **Markdown** and **AsciiDoc** editors to include the changes made in the aforementioned pull request.

For the Markdown editor, added notes about the two new blockquote styling types.

For the AsciiDoc editor, added a note about the Success admonition extension that was created and included an example on how to invoke the admonition.