### PR TITLE
Delete unnecessary double quote ("") in docker-compose.yaml file

### DIFF
--- a/install/docker.md
+++ b/install/docker.md
@@ -141,7 +141,6 @@ This is however not a secure way to run containers. Make sure you understand the
 Here's a full example of a Docker Compose file for Wiki.js, using PostgreSQL, listening on port 80:
 
 ```yaml
-version: 3
 services:
 
   db:
@@ -169,7 +168,7 @@ services:
       DB_NAME: wiki
     restart: unless-stopped
     ports:
-      - 80:3000
+      - "80:3000"
 
 volumes:
   db-data:

--- a/install/docker.md
+++ b/install/docker.md
@@ -141,7 +141,7 @@ This is however not a secure way to run containers. Make sure you understand the
 Here's a full example of a Docker Compose file for Wiki.js, using PostgreSQL, listening on port 80:
 
 ```yaml
-version: "3"
+version: 3
 services:
 
   db:
@@ -151,7 +151,7 @@ services:
       POSTGRES_PASSWORD: wikijsrocks
       POSTGRES_USER: wikijs
     logging:
-      driver: "none"
+      driver: none
     restart: unless-stopped
     volumes:
       - db-data:/var/lib/postgresql/data
@@ -169,7 +169,7 @@ services:
       DB_NAME: wiki
     restart: unless-stopped
     ports:
-      - "80:3000"
+      - 80:3000
 
 volumes:
   db-data:


### PR DESCRIPTION
The double quote has caused deployment failure, and it is not needed to have double quote on those variables.