### PR TITLE
Remove logging from install/docker-desktop.md

### DIFF
--- a/install/docker-desktop.md
+++ b/install/docker-desktop.md
@@ -38,8 +38,6 @@ services:
       POSTGRES_DB: wiki
       POSTGRES_PASSWORD: wikijsrocks
       POSTGRES_USER: wikijs
-    logging:
-      driver: "none"
     restart: unless-stopped
     volumes:
       - db-data:/var/lib/postgresql/data


### PR DESCRIPTION
This option prevents the Postgres container from starting up. It says:

`Error response from daemon: configured logging driver does not support reading`

I am using Windows 11, 24H2 version.

`docker info` returns `Logging Driver: json-file`. The option can be either removed and left as the default value of `json-file` or changed to something else so that it doesn't block the application startup.